### PR TITLE
fix fragment transaction IllegalStateException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath 'me.tatarka:gradle-retrolambda:3.2.5'
         classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'

--- a/common-android-utils/build.gradle
+++ b/common-android-utils/build.gradle
@@ -5,12 +5,12 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 android {
 
-    compileSdkVersion 24
-    buildToolsVersion "24.0.3"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.0"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -50,10 +50,10 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'br.com.zbra:android-linq:1.0.1'
-    compile 'com.android.support:support-v4:24.2.1'
-    compile 'com.android.support:support-v13:24.2.1'
-    compile 'com.android.support:design:24.2.1'
-    compile 'com.android.support:recyclerview-v7:24.2.1'
+    compile 'com.android.support:support-v4:25.0.0'
+    compile 'com.android.support:support-v13:25.0.0'
+    compile 'com.android.support:design:25.0.0'
+    compile 'com.android.support:recyclerview-v7:25.0.0'
     compile 'com.github.orhanobut:hawk:1.23'
     compile 'com.google.code.gson:gson:2.7'
     compile 'com.jakewharton:butterknife:8.2.1'

--- a/common-android-utils/src/main/java/com/common/android/utils/extensions/FragmentExtensions.java
+++ b/common-android-utils/src/main/java/com/common/android/utils/extensions/FragmentExtensions.java
@@ -144,18 +144,30 @@ final public class FragmentExtensions {
     public static void popBackStackImmediate() {
         if (LOGGING_ENABLED)
             Logger.v(TAG, "[popBackStackImmediate]");
+
+        if (!ContextHelper.isRunning.get())
+            return;
+
         getAppCompatActivity().getSupportFragmentManager().popBackStackImmediate();
     }
 
     public static void popBackStack() {
         if (LOGGING_ENABLED)
             Logger.v(TAG, "[popBackStack]");
+
+        if (!ContextHelper.isRunning.get())
+            return;
+
         getAppCompatActivity().getSupportFragmentManager().popBackStack();
     }
 
     public static void clearBackStack() {
         if (LOGGING_ENABLED)
             Logger.v(TAG, "[clearBackStack]");
+
+        if (!ContextHelper.isRunning.get())
+            return;
+
         getAppCompatActivity().getSupportFragmentManager().popBackStackImmediate(null, FragmentManager.POP_BACK_STACK_INCLUSIVE);
     }
 


### PR DESCRIPTION
fix bug for 

`
Caused by java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
       at android.support.v4.app.FragmentManagerImpl.checkStateLoss(FragmentManager.java:1533)
       at android.support.v4.app.FragmentManagerImpl.popBackStackImmediate(FragmentManager.java:619)
`
